### PR TITLE
Supports allowed_address_pairs for Tacker CP

### DIFF
--- a/tacker/vnfm/tosca/lib/tacker_nfv_defs.yaml
+++ b/tacker/vnfm/tosca/lib/tacker_nfv_defs.yaml
@@ -233,6 +233,9 @@ node_types:
       anti_spoofing_protection:
         type: boolean
         required: false
+      allowed_address_pairs:
+        type: list
+        required: false
       security_groups:
         type: list
         required: false


### PR DESCRIPTION
tosca.nodes.nfv.CP.Tacker supports allowed_address_pairs. This is required for virtural IP.
https://bugs.launchpad.net/tacker/+bug/1664805